### PR TITLE
Log to stdout instead of a file for cloud observability

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,12 +15,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	logFile, err := os.OpenFile(cfg.LogFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer logFile.Close()
-	log.SetOutput(logFile)
+	// Log to stdout so the platform (Railway, Docker, etc.) captures logs.
+	log.SetOutput(os.Stdout)
 
 	msg, err := message.LoadMessaged()
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,6 @@ type AppConfig struct {
 	TKey                  string
 	MongoURI              string `json:"mongo_uri"`
 	DBName                string `json:"db_name"`
-	LogFileName           string `json:"log_file_name"`
 	DebugMode             bool   `json:"debug_mode"`
 }
 

--- a/config/config_dev.json
+++ b/config/config_dev.json
@@ -6,6 +6,5 @@
   "debug_mode": true,
   "long_polling_timeout": 60,
   "mongo_uri": "mongodb://localhost:27017",
-  "db_name": "book_club_boot",
-  "log_file_name": "application.log"
+  "db_name": "book_club_boot"
 }

--- a/config/config_prod.json
+++ b/config/config_prod.json
@@ -6,6 +6,5 @@
   "debug_mode": false,
   "long_polling_timeout": 60,
   "mongo_uri": "mongodb://mongo:27017",
-  "db_name": "book_club_boot",
-  "log_file_name": "application.log"
+  "db_name": "book_club_boot"
 }

--- a/config/config_sandbox.json
+++ b/config/config_sandbox.json
@@ -6,6 +6,5 @@
   "debug_mode": true,
   "long_polling_timeout": 60,
   "mongo_uri": "mongodb://RAILWAY_MONGO_URL_NOT_SET:27017",
-  "db_name": "book_club_sandbox",
-  "log_file_name": "application.log"
+  "db_name": "book_club_sandbox"
 }


### PR DESCRIPTION
Closes #20

## Summary
- Replaced `log.SetOutput(logFile)` with `log.SetOutput(os.Stdout)` in `cmd/main.go`, removing the `application.log` file handling entirely. Logs now surface in Railway's log viewer and the local terminal with no environment-conditional logic.
- Removed the now-dead `log_file_name` field from the `AppConfig` struct and from `config_dev.json`, `config_sandbox.json`, and `config_prod.json`.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -short ./...` passes
- [ ] After deploy, confirm application logs appear in Railway's log viewer

---
🤖 Created by [Claude Code](https://claude.ai/code) · Model: claude-opus-4-8
