### PR TITLE
Session persistence data layer: models, SessionRepository, indexes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"BookClubBot/config"
 	"BookClubBot/internal/repository"
 	"BookClubBot/message"
+	"context"
 	"log"
 	"os"
 )
@@ -37,6 +38,17 @@ func main() {
 
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	// Session persistence layer. The bot does not consume it yet (wiring lands
+	// in a follow-up), but the indexes — notably the unique "one active session"
+	// index — must exist before sessions are written, so create them at startup.
+	sessionRepository, err := repository.NewSessionRepository(db)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := sessionRepository.EnsureIndexes(context.Background()); err != nil {
+		log.Fatalf("error ensuring session indexes: '%v'", err)
 	}
 
 	b := bot.NewBot(cfg, msg, subRepository, settingsRepository)

--- a/docs/book-club-flow.md
+++ b/docs/book-club-flow.md
@@ -1,0 +1,346 @@
+# Book Club Flow & Session Schema
+
+This document describes the **business flow** of a book club round and the
+**MongoDB schema** that backs it. It is the source of truth for the
+session feature — it supersedes the "Models defined but not yet persisted"
+section of [`db-schema.md`](./db-schema.md).
+
+The goal of the feature is **persistence**: an in-flight gathering or poll must
+survive a process restart. Today the round lives only in memory
+(`bot.bookGathering` + `bot.telegramPoll`) and the lifecycle is driven by
+`time.Sleep` goroutines, so a restart loses everything. Moving the state to
+MongoDB and driving deadlines from persisted timestamps fixes both.
+
+---
+
+## The flow
+
+A **session** is one complete round. There is **at most one active session at a
+time** (a second `/start_vote` while one is live is rejected).
+
+### Step 1 — Book gathering
+
+1. A subscriber runs `/start_vote`.
+2. The bot DMs every active subscriber and walks each one through the book
+   submission conversation, one question at a time:
+   `title → author → description → cover image → done`.
+   (`/skip` opts a participant out.)
+3. The gathering has a **deadline**. When the deadline passes the gathering
+   ends **regardless** of who has not finished — partial/absent submissions are
+   simply dropped from the poll. The gathering also ends early if everyone has
+   either finished or skipped.
+4. A pre-deadline **reminder** is sent to participants who have not finished.
+
+### Step 2 — Voting
+
+1. The bot posts the collected books as a native Telegram poll in the group.
+2. The poll has a **deadline**. It closes when the deadline passes **or** when
+   every eligible subscriber has voted, whichever comes first.
+3. A pre-deadline **reminder** is sent to the group.
+4. On close the bot tallies votes and announces the winner. Ties are possible
+   (`winners` can hold more than one book) and fall back to manual resolution.
+
+### Step 3 — Reading & reviews (future, not implemented yet)
+
+After a winner is chosen, the club reads **the winning book**. Every subscriber:
+
+1. Gets a reading status (`reading → finished`).
+2. Returns to the bot when done to submit a **rating** and a short **review**.
+
+The schema below already reserves a `reading` sub-document for this so step 3
+can be added without a migration. Do not build the step-3 behaviour yet — just
+keep the shape stable.
+
+---
+
+## Lifecycle / status
+
+A session moves through these statuses:
+
+| Status | Meaning | Active? |
+|---|---|---|
+| `gathering` | Collecting book submissions (step 1) | yes |
+| `voting` | Telegram poll is open (step 2) | yes |
+| `reading` | Winner chosen, club is reading (step 3, future) | yes |
+| `completed` | Round finished and archived | no |
+| `cancelled` | Aborted (e.g. fewer than 2 books gathered, bot removed) | no |
+
+"Active" = the recovery loop is responsible for advancing it. There must be at
+most **one** session whose status is active at any time (enforced by a partial
+unique index — see [Indexes](#indexes)).
+
+---
+
+## Deadlines & recovery
+
+Each timed phase stores **absolute timestamps**, not durations:
+
+- `deadline` — when the phase must end.
+- `notifyAt` — when to send the pre-deadline reminder.
+- `notifiedAt` — set once the reminder is sent, so it fires exactly once
+  (idempotency across restarts).
+
+A single **scheduler/recovery loop** (a ticker, ~every 15s) is the only driver:
+
+- On startup it loads the active session (if any) and resumes from its current
+  status — no goroutines to re-spawn.
+- On each tick, for the active session:
+  - if `now >= notifyAt` and `notifiedAt` is unset → send reminder, set
+    `notifiedAt`;
+  - if `now >= deadline` → end the phase (gathering → start poll, or
+    voting → close poll & announce);
+  - for voting only: if all eligible subscribers have voted
+    (`len(voterIds) >= totalParticipants`) → close early.
+
+Because every action is keyed off persisted state and guarded by an idempotency
+marker, a crash at any point is safe — the next tick re-evaluates and continues.
+
+### Why a ticker loop (and not per-deadline timers)
+
+The driver is **one ticker goroutine**, started once in `Run()`:
+
+```go
+ticker := time.NewTicker(15 * time.Second)
+for range ticker.C {
+    b.checkActiveSession(ctx) // load the active session, act on due deadlines
+}
+```
+
+This is deliberately chosen over per-deadline `time.AfterFunc`/`time.Sleep`
+goroutines (the current in-memory approach):
+
+- **Recovery is free.** The loop doesn't care when it started. The first tick
+  after a restart simply sees `now >= deadline` and fires — there are no
+  remaining durations to recompute and no goroutines to re-spawn. Catching up
+  after downtime and normal operation are the *same* code path, so there is no
+  separate recovery path to get wrong.
+- **Idempotent by construction.** The `notifiedAt` marker and the `status`
+  transition make acting twice a no-op, so a crash mid-action is safe.
+- **One code path** handles both "deadline passed while running" and "deadline
+  passed while we were down."
+
+Trade-off: a deadline may fire up to one tick (~15s) late. For a book club
+measured in days this is irrelevant. Rejected alternatives: per-deadline timers
+(restart-fragile), MongoDB TTL indexes (only delete documents, can't run
+logic), and change streams / external cron (extra infra a single-instance bot
+doesn't need).
+
+Implementation notes:
+
+- **No overlapping ticks.** Run the per-tick checks sequentially in the single
+  ticker goroutine (or guard with a "busy" flag) so a long-running tick can't
+  start a second concurrent pass over the same session.
+- **Poll early-close has two paths.** The "all eligible voted"
+  (`len(voterIds) >= totalParticipants`) check runs inside the tick as the
+  safety net, while a live `PollAnswer` update can still close the poll
+  immediately as the fast path. Both converge on the same idempotent close
+  routine.
+
+---
+
+## Schema
+
+MongoDB database: **`book_club_boot`**. New collection: **`book_club_sessions`**.
+
+```json
+{
+  "_id": "<ObjectID>",
+  "name": "June 2026",
+  "status": "gathering",
+  "createdBy": 123456789,
+  "createdAt": "2026-06-01T10:00:00Z",
+  "updatedAt": "2026-06-01T10:00:00Z",
+
+  "gathering": {
+    "deadline": "2026-06-03T10:00:00Z",
+    "notifyAt": "2026-06-03T08:00:00Z",
+    "notifiedAt": null,
+    "participants": [
+      {
+        "subscriberId": 123456789,
+        "firstName": "Andrei",
+        "lastName": "Haravy",
+        "nick": "andreiharavy",
+        "step": "author",
+        "book": {
+          "title": "The Pragmatic Programmer",
+          "author": "",
+          "description": "",
+          "photoId": ""
+        },
+        "invitedAt": "2026-06-01T10:00:00Z",
+        "submittedAt": null
+      }
+    ]
+  },
+
+  "voting": {
+    "telegramPollId": 42,
+    "deadline": "2026-06-04T10:00:00Z",
+    "notifyAt": "2026-06-04T08:00:00Z",
+    "notifiedAt": null,
+    "totalParticipants": 5,
+    "voterIds": [123456789, 987654321],
+    "startedAt": "2026-06-03T10:00:00Z",
+    "closedAt": null
+  },
+
+  "winners": [
+    {
+      "subscriberId": 123456789,
+      "title": "The Pragmatic Programmer",
+      "author": "David Thomas"
+    }
+  ],
+
+  "reading": null
+}
+```
+
+### `book_club_sessions` — top level
+
+| Field | BSON type | Notes |
+|---|---|---|
+| `_id` | ObjectID | Auto-generated |
+| `name` | string | Human label, auto-generated (e.g. `"June 2026"`) |
+| `status` | string | One of the lifecycle statuses above |
+| `createdBy` | int64 | Telegram user ID who ran `/start_vote` |
+| `createdAt` | date | Session creation time |
+| `updatedAt` | date | Last mutation; bumped on every write |
+| `gathering` | object | Step 1 sub-document |
+| `voting` | object \| null | Step 2 sub-document; `null` until the poll starts |
+| `winners` | array | 0 (no winner / cancelled), 1, or many (tie) entries |
+| `reading` | object \| null | Step 3 sub-document; `null` until reserved for future use |
+| `activeLock` | bool (present only while active) | Internal lock backing the unique "one active session" index; omitted in terminal states. See [Indexes](#indexes) |
+
+### `gathering`
+
+| Field | BSON type | Notes |
+|---|---|---|
+| `deadline` | date | When gathering force-ends |
+| `notifyAt` | date | When the pre-deadline reminder is due |
+| `notifiedAt` | date \| null | Set once the reminder has been sent |
+| `participants` | array | Embedded `Participant` objects |
+
+### `Participant` (embedded)
+
+Holds **in-progress conversation state** so a restart resumes each user exactly
+where they left off. A finished participant's `book` is the completed
+submission; the poll is built from participants whose `step` is `done`.
+
+| Field | BSON type | Notes |
+|---|---|---|
+| `subscriberId` | int64 | References `subscribers._id` |
+| `firstName` | string | Snapshot at invite time |
+| `lastName` | string | Snapshot |
+| `nick` | string | Snapshot |
+| `step` | string | `book` \| `author` \| `description` \| `image` \| `done` \| `skipped` |
+| `book` | object \| null | Partial while in progress, complete when `step == done` |
+| `invitedAt` | date | When the bot DMed this participant |
+| `submittedAt` | date \| null | When `step` reached `done` |
+
+**`book` (embedded):**
+
+| Field | BSON type | Notes |
+|---|---|---|
+| `title` | string | |
+| `author` | string | |
+| `description` | string | |
+| `photoId` | string | Telegram `FileID`; empty string if no cover submitted |
+
+### `voting`
+
+| Field | BSON type | Notes |
+|---|---|---|
+| `telegramPollId` | int32 | Telegram **message ID** of the poll |
+| `deadline` | date | When the poll force-closes |
+| `notifyAt` | date | When the pre-deadline reminder is due |
+| `notifiedAt` | date \| null | Set once the reminder has been sent |
+| `totalParticipants` | int32 | Snapshot of eligible voter count at poll start |
+| `voterIds` | array<int64> | Unique voters; powers dedup, count, and early close |
+| `startedAt` | date | |
+| `closedAt` | date \| null | `null` while the poll is open |
+
+> `voterIds` replaces the old `participantsVoted` counter. A bare count cannot
+> survive a restart without risking double-counting, since Telegram does not
+> reliably re-deliver historical `PollAnswer` updates.
+
+### `Winner` (embedded array element)
+
+| Field | BSON type | Notes |
+|---|---|---|
+| `subscriberId` | int64 | Who suggested the winning book |
+| `title` | string | Copied from the winning submission |
+| `author` | string | |
+
+### `reading` (future — step 3)
+
+`null` for now. Reserved shape:
+
+```json
+{
+  "book": {
+    "title": "The Pragmatic Programmer",
+    "author": "David Thomas",
+    "photoId": "AgACAgIAAxk...",
+    "subscriberId": 123456789
+  },
+  "members": [
+    {
+      "subscriberId": 123456789,
+      "status": "reading",
+      "rating": null,
+      "review": null,
+      "startedAt": "2026-06-05T10:00:00Z",
+      "finishedAt": null
+    }
+  ]
+}
+```
+
+| Field | BSON type | Notes |
+|---|---|---|
+| `book` | object | The winning book the club reads |
+| `members[].subscriberId` | int64 | References `subscribers._id` |
+| `members[].status` | string | `reading` \| `finished` \| `abandoned` |
+| `members[].rating` | int32 \| null | e.g. 1–5; `null` until submitted |
+| `members[].review` | string \| null | Free text; `null` until submitted |
+| `members[].startedAt` | date | When reading began |
+| `members[].finishedAt` | date \| null | When the member finished |
+
+---
+
+## Indexes
+
+| Index | Purpose |
+|---|---|
+| Unique partial on `activeLock` where `activeLock` exists | Enforce **one active session at a time** |
+| `createdAt: -1` | List past sessions / fetch the latest for history |
+
+### Why `activeLock` instead of an index on `status`
+
+Conceptually we want "at most one session whose `status ∈ {gathering, voting,
+reading}`". The natural index would be a unique partial index with
+`partialFilterExpression: { status: { $in: [...] } }` — but **`$in` inside a
+partial index filter is only supported from MongoDB 6.3**, and CI/prod run
+**MongoDB 6.0**. `$exists` is supported on all versions, so instead each session
+carries an internal `activeLock` field that is **present only while active** and
+absent once it reaches a terminal status. A unique index over the docs where
+`activeLock` exists then permits exactly one active session.
+
+`activeLock` is managed entirely by `SessionRepository` (set on create / active
+transitions, unset on `completed`/`cancelled`) and is never read by application
+logic — `status` remains the source of truth for the phase.
+
+---
+
+## History
+
+History falls out of the schema for free: completed rounds stay in
+`book_club_sessions` with `status: completed` and `winners` populated.
+
+- "What are we reading this month" → latest session with status `reading` /
+  `completed`, look at `winners` (or `reading.book`).
+- "What has been suggested" → `gathering.participants[].book` across sessions.
+
+Planned read helpers: `GetActiveSession`, `GetCurrentBook`, `ListPastSessions`.

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -58,6 +58,11 @@ Single-document collection. Stores bot-level runtime settings that must survive 
 
 ## Models defined but not yet persisted
 
+> **Superseded.** The session schema below is an earlier draft. The authoritative
+> design for the book-club round (gathering → voting → reading) and its MongoDB
+> schema now lives in [`book-club-flow.md`](./book-club-flow.md). Follow that doc
+> for the feature; the section below is kept only for historical reference.
+
 The following structs exist in `internal/models/mongodb.go` and have BSON tags, but there is currently **no repository or collection** wired up for them. They represent the intended next phase of the schema (replacing in-memory state with MongoDB).
 
 ### `BookClubSession` (planned collection: `book_club_sessions`)

--- a/internal/models/mongodb.go
+++ b/internal/models/mongodb.go
@@ -15,38 +15,125 @@ type Subscriber struct {
 	JoinedAt  time.Time `bson:"joinedAt"`
 }
 
-type BookSuggestion struct {
-	SubscriberID int64     `bson:"subscriberId"`
-	BookTitle    string    `bson:"bookTitle"`
-	Author       string    `bson:"author"`
-	Description  string    `bson:"description"`
-	PhotoID      string    `bson:"photoId"`
-	SuggestedAt  time.Time `bson:"suggestedAt"`
+// Session statuses. The first three are "active" — at most one session may be
+// in any active status at a time (see SessionRepository.EnsureIndexes).
+const (
+	StatusGathering = "gathering"
+	StatusVoting    = "voting"
+	StatusReading   = "reading"
+	StatusCompleted = "completed"
+	StatusCancelled = "cancelled"
+)
+
+// Participant submission steps during book gathering.
+const (
+	StepBook        = "book"
+	StepAuthor      = "author"
+	StepDescription = "description"
+	StepImage       = "image"
+	StepDone        = "done"
+	StepSkipped     = "skipped"
+)
+
+// Reading member statuses (step 3, reserved for future use).
+const (
+	ReadingInProgress = "reading"
+	ReadingFinished   = "finished"
+	ReadingAbandoned  = "abandoned"
+)
+
+// Book is a single book submission (partial while a participant is still
+// answering questions, complete once their step reaches StepDone).
+type Book struct {
+	Title       string `bson:"title"`
+	Author      string `bson:"author"`
+	Description string `bson:"description"`
+	PhotoID     string `bson:"photoId"`
 }
 
+// Participant holds one subscriber's in-progress conversation state during book
+// gathering, so a restart resumes them exactly where they left off.
+type Participant struct {
+	SubscriberID int64      `bson:"subscriberId"`
+	FirstName    string     `bson:"firstName"`
+	LastName     string     `bson:"lastName"`
+	Nick         string     `bson:"nick"`
+	Step         string     `bson:"step"`
+	Book         *Book      `bson:"book"`
+	InvitedAt    time.Time  `bson:"invitedAt"`
+	SubmittedAt  *time.Time `bson:"submittedAt"`
+}
+
+// Gathering is the book-collection phase (step 1).
+type Gathering struct {
+	Deadline     time.Time      `bson:"deadline"`
+	NotifyAt     time.Time      `bson:"notifyAt"`
+	NotifiedAt   *time.Time     `bson:"notifiedAt"`
+	Participants []*Participant `bson:"participants"`
+}
+
+// Voting is the Telegram poll phase (step 2).
 type Voting struct {
-	TelegramPollID    string     `bson:"telegramPollId"`
-	StartedAt         time.Time  `bson:"startedAt"`
-	CompletedAt       *time.Time `bson:"completedAt"`
-	ParticipantsVoted int        `bson:"participantsVoted"`
+	TelegramPollID    int        `bson:"telegramPollId"`
+	Deadline          time.Time  `bson:"deadline"`
+	NotifyAt          time.Time  `bson:"notifyAt"`
+	NotifiedAt        *time.Time `bson:"notifiedAt"`
 	TotalParticipants int        `bson:"totalParticipants"`
+	VoterIDs          []int64    `bson:"voterIds"`
+	StartedAt         time.Time  `bson:"startedAt"`
+	ClosedAt          *time.Time `bson:"closedAt"`
 }
 
+// Winner is a winning book. A round can have several winners on a tie.
 type Winner struct {
-	BookTitle    string `bson:"bookTitle"`
-	Author       string `bson:"author"`
-	Description  string `bson:"description"`
-	PhotoID      string `bson:"photoId"`
 	SubscriberID int64  `bson:"subscriberId"`
+	Title        string `bson:"title"`
+	Author       string `bson:"author"`
 }
 
+// ReadingMember is one subscriber's progress and review of the winning book
+// (step 3, reserved for future use).
+type ReadingMember struct {
+	SubscriberID int64      `bson:"subscriberId"`
+	Status       string     `bson:"status"`
+	Rating       *int       `bson:"rating"`
+	Review       *string    `bson:"review"`
+	StartedAt    time.Time  `bson:"startedAt"`
+	FinishedAt   *time.Time `bson:"finishedAt"`
+}
+
+// Reading is the post-vote reading phase (step 3, reserved for future use).
+type Reading struct {
+	Book    Book             `bson:"book"`
+	Members []*ReadingMember `bson:"members"`
+}
+
+// BookClubSession is one complete round: gathering → voting → reading.
 type BookClubSession struct {
-	ID              primitive.ObjectID `bson:"_id,omitempty"`
-	Name            string             `bson:"name"`
-	Status          string             `bson:"status"`
-	StartedAt       time.Time          `bson:"startedAt"`
-	CreatedBy       int64              `bson:"createdBy"`
-	BookSuggestions []BookSuggestion   `bson:"bookSuggestions"`
-	Voting          Voting             `bson:"voting"`
-	Winner          Winner             `bson:"winner"`
+	ID        primitive.ObjectID `bson:"_id,omitempty"`
+	Name      string             `bson:"name"`
+	Status    string             `bson:"status"`
+	CreatedBy int64              `bson:"createdBy"`
+	CreatedAt time.Time          `bson:"createdAt"`
+	UpdatedAt time.Time          `bson:"updatedAt"`
+	Gathering Gathering          `bson:"gathering"`
+	Voting    *Voting            `bson:"voting"`
+	Winners   []Winner           `bson:"winners"`
+	Reading   *Reading           `bson:"reading"`
+
+	// ActiveLock is present only while the session is in an active status. A
+	// unique partial index on its existence guarantees at most one active
+	// session at a time. It is never read by application code; SessionRepository
+	// sets and unsets it as the status changes.
+	ActiveLock *bool `bson:"activeLock,omitempty"`
+}
+
+// IsActive reports whether a session is in an active (non-terminal) status.
+func (s *BookClubSession) IsActive() bool {
+	switch s.Status {
+	case StatusGathering, StatusVoting, StatusReading:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/models/mongodb.go
+++ b/internal/models/mongodb.go
@@ -128,12 +128,18 @@ type BookClubSession struct {
 	ActiveLock *bool `bson:"activeLock,omitempty"`
 }
 
-// IsActive reports whether a session is in an active (non-terminal) status.
-func (s *BookClubSession) IsActive() bool {
-	switch s.Status {
+// IsActiveStatus reports whether a status is active (non-terminal). It is the
+// single source of truth for which statuses count as active.
+func IsActiveStatus(status string) bool {
+	switch status {
 	case StatusGathering, StatusVoting, StatusReading:
 		return true
 	default:
 		return false
 	}
+}
+
+// IsActive reports whether a session is in an active (non-terminal) status.
+func (s *BookClubSession) IsActive() bool {
+	return IsActiveStatus(s.Status)
 }

--- a/internal/repository/errors.go
+++ b/internal/repository/errors.go
@@ -4,3 +4,7 @@ import "errors"
 
 // ErrNotFound is returned when a requested document does not exist.
 var ErrNotFound = errors.New("not found")
+
+// ErrActiveSessionExists is returned when creating a session while another
+// active (gathering/voting/reading) session already exists.
+var ErrActiveSessionExists = errors.New("an active session already exists")

--- a/internal/repository/session.go
+++ b/internal/repository/session.go
@@ -131,9 +131,11 @@ func (s *SessionRepository) UpdateParticipant(ctx context.Context, id primitive.
 }
 
 // AddVoter records that a subscriber has voted (idempotent via $addToSet).
+// It requires voting to have started; if the session has no voting sub-document
+// yet, it returns ErrNotFound rather than a raw "$addToSet on null" write error.
 func (s *SessionRepository) AddVoter(ctx context.Context, id primitive.ObjectID, voterID int64) error {
 	collection := s.db.Collection(sessions_collection)
-	filter := bson.M{"_id": id}
+	filter := bson.M{"_id": id, "voting": bson.M{"$ne": nil}}
 	update := bson.M{
 		"$addToSet": bson.M{"voting.voterIds": voterID},
 		"$set":      bson.M{"updatedAt": time.Now().UTC()},
@@ -203,7 +205,7 @@ func (s *SessionRepository) SetStatus(ctx context.Context, id primitive.ObjectID
 
 	set := bson.M{"status": status, "updatedAt": time.Now().UTC()}
 	update := bson.M{"$set": set}
-	if isActiveStatus(status) {
+	if models.IsActiveStatus(status) {
 		set["activeLock"] = true
 	} else {
 		update["$unset"] = bson.M{"activeLock": ""}
@@ -266,15 +268,6 @@ func (s *SessionRepository) setField(ctx context.Context, id primitive.ObjectID,
 		return ErrNotFound
 	}
 	return nil
-}
-
-func isActiveStatus(status string) bool {
-	switch status {
-	case models.StatusGathering, models.StatusVoting, models.StatusReading:
-		return true
-	default:
-		return false
-	}
 }
 
 // activeLock returns a pointer to true when active, or nil so the field is

--- a/internal/repository/session.go
+++ b/internal/repository/session.go
@@ -152,6 +152,11 @@ func (s *SessionRepository) AddVoter(ctx context.Context, id primitive.ObjectID,
 // StartVoting attaches the voting sub-document and moves the session into the
 // voting status. The session stays active, so activeLock is left in place.
 func (s *SessionRepository) StartVoting(ctx context.Context, id primitive.ObjectID, voting *models.Voting) error {
+	// Store an empty array (not BSON null) so later $addToSet on voterIds works.
+	if voting.VoterIDs == nil {
+		voting.VoterIDs = []int64{}
+	}
+
 	collection := s.db.Collection(sessions_collection)
 	filter := bson.M{"_id": id}
 	update := bson.M{"$set": bson.M{

--- a/internal/repository/session.go
+++ b/internal/repository/session.go
@@ -66,10 +66,7 @@ func (s *SessionRepository) CreateSession(ctx context.Context, session *models.B
 	collection := s.db.Collection(sessions_collection)
 	res, err := collection.InsertOne(ctx, session)
 	if err != nil {
-		if mongo.IsDuplicateKeyError(err) {
-			return ErrActiveSessionExists
-		}
-		return err
+		return mapActiveLockConflict(err)
 	}
 	if oid, ok := res.InsertedID.(primitive.ObjectID); ok {
 		session.ID = oid
@@ -152,7 +149,10 @@ func (s *SessionRepository) AddVoter(ctx context.Context, id primitive.ObjectID,
 }
 
 // StartVoting attaches the voting sub-document and moves the session into the
-// voting status. The session stays active, so activeLock is left in place.
+// voting status. It (re)asserts activeLock so the "active status ⟺ activeLock
+// present" invariant holds locally, rather than relying on the lock already
+// being there; setting it on the same document is a no-op, and the unique index
+// surfaces ErrActiveSessionExists if another session is somehow active.
 func (s *SessionRepository) StartVoting(ctx context.Context, id primitive.ObjectID, voting *models.Voting) error {
 	// Store an empty array (not BSON null) so later $addToSet on voterIds works.
 	if voting.VoterIDs == nil {
@@ -162,14 +162,15 @@ func (s *SessionRepository) StartVoting(ctx context.Context, id primitive.Object
 	collection := s.db.Collection(sessions_collection)
 	filter := bson.M{"_id": id}
 	update := bson.M{"$set": bson.M{
-		"voting":    voting,
-		"status":    models.StatusVoting,
-		"updatedAt": time.Now().UTC(),
+		"voting":     voting,
+		"status":     models.StatusVoting,
+		"activeLock": true,
+		"updatedAt":  time.Now().UTC(),
 	}}
 
 	res, err := collection.UpdateOne(ctx, filter, update)
 	if err != nil {
-		return err
+		return mapActiveLockConflict(err)
 	}
 	if res.MatchedCount == 0 {
 		return ErrNotFound
@@ -213,7 +214,7 @@ func (s *SessionRepository) SetStatus(ctx context.Context, id primitive.ObjectID
 
 	res, err := collection.UpdateOne(ctx, filter, update)
 	if err != nil {
-		return err
+		return mapActiveLockConflict(err)
 	}
 	if res.MatchedCount == 0 {
 		return ErrNotFound
@@ -268,6 +269,16 @@ func (s *SessionRepository) setField(ctx context.Context, id primitive.ObjectID,
 		return ErrNotFound
 	}
 	return nil
+}
+
+// mapActiveLockConflict translates a duplicate-key error from the unique
+// activeLock index into ErrActiveSessionExists, so every write that could
+// collide with an existing active session reports the condition the same way.
+func mapActiveLockConflict(err error) error {
+	if mongo.IsDuplicateKeyError(err) {
+		return ErrActiveSessionExists
+	}
+	return err
 }
 
 // activeLock returns a pointer to true when active, or nil so the field is

--- a/internal/repository/session.go
+++ b/internal/repository/session.go
@@ -1,0 +1,283 @@
+package repository
+
+import (
+	"BookClubBot/internal/models"
+	"context"
+	"errors"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const sessions_collection = "book_club_sessions"
+
+type SessionRepository struct {
+	db *mongo.Database
+}
+
+func NewSessionRepository(db *mongo.Database) (*SessionRepository, error) {
+	if db == nil {
+		return nil, ErrNilDatabase
+	}
+	return &SessionRepository{
+		db: db,
+	}, nil
+}
+
+// EnsureIndexes creates the indexes the session collection relies on:
+//   - a unique partial index on activeLock that allows at most one active
+//     session at a time (only active sessions carry the field);
+//   - a descending createdAt index for history listing.
+//
+// MongoDB 6.0 does not support $in inside partialFilterExpression, so the
+// "one active session" rule is expressed via the existence of activeLock
+// rather than a status set.
+func (s *SessionRepository) EnsureIndexes(ctx context.Context) error {
+	collection := s.db.Collection(sessions_collection)
+	_, err := collection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys: bson.D{{Key: "activeLock", Value: 1}},
+			Options: options.Index().
+				SetName("uniq_active_session").
+				SetUnique(true).
+				SetPartialFilterExpression(bson.M{"activeLock": bson.M{"$exists": true}}),
+		},
+		{
+			Keys:    bson.D{{Key: "createdAt", Value: -1}},
+			Options: options.Index().SetName("createdAt_desc"),
+		},
+	})
+	return err
+}
+
+// CreateSession inserts a new session. createdAt/updatedAt are stamped here, and
+// activeLock is set when the session starts in an active status so the unique
+// index is enforced. The generated ID is written back onto the session.
+// Returns ErrActiveSessionExists if another active session already exists.
+func (s *SessionRepository) CreateSession(ctx context.Context, session *models.BookClubSession) error {
+	now := time.Now().UTC()
+	session.CreatedAt = now
+	session.UpdatedAt = now
+	session.ActiveLock = activeLock(session.IsActive())
+
+	collection := s.db.Collection(sessions_collection)
+	res, err := collection.InsertOne(ctx, session)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return ErrActiveSessionExists
+		}
+		return err
+	}
+	if oid, ok := res.InsertedID.(primitive.ObjectID); ok {
+		session.ID = oid
+	}
+	return nil
+}
+
+// GetActiveSession returns the single active session, or (nil, nil) if there is
+// none.
+func (s *SessionRepository) GetActiveSession(ctx context.Context) (*models.BookClubSession, error) {
+	collection := s.db.Collection(sessions_collection)
+	filter := bson.M{"activeLock": bson.M{"$exists": true}}
+
+	var session models.BookClubSession
+	if err := collection.FindOne(ctx, filter).Decode(&session); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &session, nil
+}
+
+// GetSessionById returns the session with the given id, or (nil, nil) if none.
+func (s *SessionRepository) GetSessionById(ctx context.Context, id primitive.ObjectID) (*models.BookClubSession, error) {
+	collection := s.db.Collection(sessions_collection)
+
+	var session models.BookClubSession
+	if err := collection.FindOne(ctx, bson.M{"_id": id}).Decode(&session); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &session, nil
+}
+
+// UpdateParticipant replaces the gathering participant matching
+// participant.SubscriberID. Returns ErrNotFound if no such participant exists.
+func (s *SessionRepository) UpdateParticipant(ctx context.Context, id primitive.ObjectID, participant *models.Participant) error {
+	collection := s.db.Collection(sessions_collection)
+	filter := bson.M{
+		"_id":                                 id,
+		"gathering.participants.subscriberId": participant.SubscriberID,
+	}
+	update := bson.M{"$set": bson.M{
+		"gathering.participants.$": participant,
+		"updatedAt":                time.Now().UTC(),
+	}}
+
+	res, err := collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// AddVoter records that a subscriber has voted (idempotent via $addToSet).
+func (s *SessionRepository) AddVoter(ctx context.Context, id primitive.ObjectID, voterID int64) error {
+	collection := s.db.Collection(sessions_collection)
+	filter := bson.M{"_id": id}
+	update := bson.M{
+		"$addToSet": bson.M{"voting.voterIds": voterID},
+		"$set":      bson.M{"updatedAt": time.Now().UTC()},
+	}
+
+	res, err := collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// StartVoting attaches the voting sub-document and moves the session into the
+// voting status. The session stays active, so activeLock is left in place.
+func (s *SessionRepository) StartVoting(ctx context.Context, id primitive.ObjectID, voting *models.Voting) error {
+	collection := s.db.Collection(sessions_collection)
+	filter := bson.M{"_id": id}
+	update := bson.M{"$set": bson.M{
+		"voting":    voting,
+		"status":    models.StatusVoting,
+		"updatedAt": time.Now().UTC(),
+	}}
+
+	res, err := collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// SetWinners stores the winning book(s) of a session.
+func (s *SessionRepository) SetWinners(ctx context.Context, id primitive.ObjectID, winners []models.Winner) error {
+	collection := s.db.Collection(sessions_collection)
+	filter := bson.M{"_id": id}
+	update := bson.M{"$set": bson.M{
+		"winners":   winners,
+		"updatedAt": time.Now().UTC(),
+	}}
+
+	res, err := collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// SetStatus transitions a session to a new status. Moving to a terminal status
+// (completed/cancelled) releases the active lock so a new session can start;
+// moving to an active status (re)asserts it.
+func (s *SessionRepository) SetStatus(ctx context.Context, id primitive.ObjectID, status string) error {
+	collection := s.db.Collection(sessions_collection)
+	filter := bson.M{"_id": id}
+
+	set := bson.M{"status": status, "updatedAt": time.Now().UTC()}
+	update := bson.M{"$set": set}
+	if isActiveStatus(status) {
+		set["activeLock"] = true
+	} else {
+		update["$unset"] = bson.M{"activeLock": ""}
+	}
+
+	res, err := collection.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// SetGatheringNotified marks the gathering pre-deadline reminder as sent.
+func (s *SessionRepository) SetGatheringNotified(ctx context.Context, id primitive.ObjectID, at time.Time) error {
+	return s.setField(ctx, id, "gathering.notifiedAt", at.UTC())
+}
+
+// SetVotingNotified marks the voting pre-deadline reminder as sent.
+func (s *SessionRepository) SetVotingNotified(ctx context.Context, id primitive.ObjectID, at time.Time) error {
+	return s.setField(ctx, id, "voting.notifiedAt", at.UTC())
+}
+
+// ListPastSessions returns completed sessions, newest first, up to limit
+// (limit <= 0 means no limit).
+func (s *SessionRepository) ListPastSessions(ctx context.Context, limit int64) ([]*models.BookClubSession, error) {
+	collection := s.db.Collection(sessions_collection)
+	opts := options.Find().SetSort(bson.D{{Key: "createdAt", Value: -1}})
+	if limit > 0 {
+		opts.SetLimit(limit)
+	}
+
+	cursor, err := collection.Find(ctx, bson.M{"status": models.StatusCompleted}, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var sessions []*models.BookClubSession
+	if err := cursor.All(ctx, &sessions); err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
+func (s *SessionRepository) setField(ctx context.Context, id primitive.ObjectID, field string, value any) error {
+	collection := s.db.Collection(sessions_collection)
+	update := bson.M{"$set": bson.M{
+		field:       value,
+		"updatedAt": time.Now().UTC(),
+	}}
+
+	res, err := collection.UpdateOne(ctx, bson.M{"_id": id}, update)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func isActiveStatus(status string) bool {
+	switch status {
+	case models.StatusGathering, models.StatusVoting, models.StatusReading:
+		return true
+	default:
+		return false
+	}
+}
+
+// activeLock returns a pointer to true when active, or nil so the field is
+// omitted from the document (omitempty) and excluded from the unique index.
+func activeLock(active bool) *bool {
+	if !active {
+		return nil
+	}
+	t := true
+	return &t
+}

--- a/internal/repository/session_test.go
+++ b/internal/repository/session_test.go
@@ -154,6 +154,24 @@ func TestAddVoter_Idempotent(t *testing.T) {
 	assert.ElementsMatch(t, []int64{100, 200}, stored.Voting.VoterIDs)
 }
 
+func TestAddVoter_BeforeVotingStarts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	mongoDB, clear := mongo_helpers.CreateTestMongoDB(t)
+	defer cleanSession(clear, mongoDB)
+	repo := newSessionRepo(t, mongoDB)
+	ctx := testCtx(t)
+
+	session := newGatheringSession(100)
+	require.NoError(t, repo.CreateSession(ctx, session))
+
+	// voting sub-document does not exist yet → ErrNotFound, not a write error.
+	err := repo.AddVoter(ctx, session.ID, 100)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestStartVotingAndSetWinners(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")

--- a/internal/repository/session_test.go
+++ b/internal/repository/session_test.go
@@ -1,0 +1,307 @@
+package repository
+
+import (
+	"BookClubBot/internal/models"
+	mongo_helpers "BookClubBot/internal/repository/testing"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func TestNewSessionRepository(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	mongoDB, clear := mongo_helpers.CreateTestMongoDB(t)
+	defer clear()
+
+	repo, err := NewSessionRepository(mongoDB)
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+
+	repo, err = NewSessionRepository(nil)
+	assert.Error(t, err)
+	assert.Nil(t, repo)
+	assert.Equal(t, ErrNilDatabase, err)
+}
+
+func TestCreateSession_EnforcesSingleActive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	mongoDB, clear := mongo_helpers.CreateTestMongoDB(t)
+	defer cleanSession(clear, mongoDB)
+	repo := newSessionRepo(t, mongoDB)
+
+	ctx := testCtx(t)
+
+	first := newGatheringSession(100)
+	require.NoError(t, repo.CreateSession(ctx, first))
+	assert.False(t, first.ID.IsZero(), "generated id should be written back")
+
+	// A second active session must be rejected by the unique index.
+	second := newGatheringSession(200)
+	err := repo.CreateSession(ctx, second)
+	assert.ErrorIs(t, err, ErrActiveSessionExists)
+
+	// Once the first is completed (lock released), a new one may start.
+	require.NoError(t, repo.SetStatus(ctx, first.ID, models.StatusCompleted))
+	third := newGatheringSession(300)
+	assert.NoError(t, repo.CreateSession(ctx, third))
+}
+
+func TestGetActiveSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	mongoDB, clear := mongo_helpers.CreateTestMongoDB(t)
+	defer cleanSession(clear, mongoDB)
+	repo := newSessionRepo(t, mongoDB)
+	ctx := testCtx(t)
+
+	// No active session yet.
+	active, err := repo.GetActiveSession(ctx)
+	assert.NoError(t, err)
+	assert.Nil(t, active)
+
+	session := newGatheringSession(100)
+	require.NoError(t, repo.CreateSession(ctx, session))
+
+	active, err = repo.GetActiveSession(ctx)
+	assert.NoError(t, err)
+	require.NotNil(t, active)
+	assert.Equal(t, session.ID, active.ID)
+	assert.Equal(t, models.StatusGathering, active.Status)
+
+	// Completing it makes GetActiveSession return nil again.
+	require.NoError(t, repo.SetStatus(ctx, session.ID, models.StatusCompleted))
+	active, err = repo.GetActiveSession(ctx)
+	assert.NoError(t, err)
+	assert.Nil(t, active)
+}
+
+func TestUpdateParticipant(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	mongoDB, clear := mongo_helpers.CreateTestMongoDB(t)
+	defer cleanSession(clear, mongoDB)
+	repo := newSessionRepo(t, mongoDB)
+	ctx := testCtx(t)
+
+	session := newGatheringSession(100)
+	require.NoError(t, repo.CreateSession(ctx, session))
+
+	now := time.Now().UTC()
+	updated := &models.Participant{
+		SubscriberID: 100,
+		FirstName:    "Andrei",
+		Step:         models.StepDone,
+		Book: &models.Book{
+			Title:       "The Pragmatic Programmer",
+			Author:      "David Thomas",
+			Description: "A classic.",
+		},
+		InvitedAt:   session.Gathering.Participants[0].InvitedAt,
+		SubmittedAt: &now,
+	}
+	require.NoError(t, repo.UpdateParticipant(ctx, session.ID, updated))
+
+	stored, err := repo.GetSessionById(ctx, session.ID)
+	require.NoError(t, err)
+	require.Len(t, stored.Gathering.Participants, 1)
+	p := stored.Gathering.Participants[0]
+	assert.Equal(t, models.StepDone, p.Step)
+	require.NotNil(t, p.Book)
+	assert.Equal(t, "The Pragmatic Programmer", p.Book.Title)
+	assert.Equal(t, "David Thomas", p.Book.Author)
+	require.NotNil(t, p.SubmittedAt)
+
+	// Unknown participant → ErrNotFound.
+	err = repo.UpdateParticipant(ctx, session.ID, &models.Participant{SubscriberID: 999})
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestAddVoter_Idempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	mongoDB, clear := mongo_helpers.CreateTestMongoDB(t)
+	defer cleanSession(clear, mongoDB)
+	repo := newSessionRepo(t, mongoDB)
+	ctx := testCtx(t)
+
+	session := newGatheringSession(100)
+	require.NoError(t, repo.CreateSession(ctx, session))
+	require.NoError(t, repo.StartVoting(ctx, session.ID, newVoting()))
+
+	require.NoError(t, repo.AddVoter(ctx, session.ID, 100))
+	require.NoError(t, repo.AddVoter(ctx, session.ID, 100)) // duplicate
+	require.NoError(t, repo.AddVoter(ctx, session.ID, 200))
+
+	stored, err := repo.GetSessionById(ctx, session.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stored.Voting)
+	assert.ElementsMatch(t, []int64{100, 200}, stored.Voting.VoterIDs)
+}
+
+func TestStartVotingAndSetWinners(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	mongoDB, clear := mongo_helpers.CreateTestMongoDB(t)
+	defer cleanSession(clear, mongoDB)
+	repo := newSessionRepo(t, mongoDB)
+	ctx := testCtx(t)
+
+	session := newGatheringSession(100)
+	require.NoError(t, repo.CreateSession(ctx, session))
+
+	require.NoError(t, repo.StartVoting(ctx, session.ID, newVoting()))
+	stored, err := repo.GetSessionById(ctx, session.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StatusVoting, stored.Status)
+	require.NotNil(t, stored.Voting)
+	assert.Equal(t, 42, stored.Voting.TelegramPollID)
+
+	// Session is still active during voting.
+	active, err := repo.GetActiveSession(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	assert.Equal(t, session.ID, active.ID)
+
+	winners := []models.Winner{{SubscriberID: 100, Title: "The Pragmatic Programmer", Author: "David Thomas"}}
+	require.NoError(t, repo.SetWinners(ctx, session.ID, winners))
+	stored, err = repo.GetSessionById(ctx, session.ID)
+	require.NoError(t, err)
+	require.Len(t, stored.Winners, 1)
+	assert.Equal(t, "The Pragmatic Programmer", stored.Winners[0].Title)
+}
+
+func TestSetGatheringAndVotingNotified(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	mongoDB, clear := mongo_helpers.CreateTestMongoDB(t)
+	defer cleanSession(clear, mongoDB)
+	repo := newSessionRepo(t, mongoDB)
+	ctx := testCtx(t)
+
+	session := newGatheringSession(100)
+	require.NoError(t, repo.CreateSession(ctx, session))
+	require.NoError(t, repo.StartVoting(ctx, session.ID, newVoting()))
+
+	at := time.Now().UTC().Truncate(time.Millisecond)
+	require.NoError(t, repo.SetGatheringNotified(ctx, session.ID, at))
+	require.NoError(t, repo.SetVotingNotified(ctx, session.ID, at))
+
+	stored, err := repo.GetSessionById(ctx, session.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stored.Gathering.NotifiedAt)
+	require.NotNil(t, stored.Voting.NotifiedAt)
+	assert.Equal(t, at, stored.Gathering.NotifiedAt.UTC())
+	assert.Equal(t, at, stored.Voting.NotifiedAt.UTC())
+}
+
+func TestListPastSessions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	mongoDB, clear := mongo_helpers.CreateTestMongoDB(t)
+	defer cleanSession(clear, mongoDB)
+	repo := newSessionRepo(t, mongoDB)
+	ctx := testCtx(t)
+
+	// Create and complete two sessions in sequence (one active at a time).
+	older := newGatheringSession(100)
+	older.Name = "May 2026"
+	require.NoError(t, repo.CreateSession(ctx, older))
+	require.NoError(t, repo.SetWinners(ctx, older.ID, []models.Winner{{SubscriberID: 100, Title: "Older"}}))
+	require.NoError(t, repo.SetStatus(ctx, older.ID, models.StatusCompleted))
+
+	newer := newGatheringSession(200)
+	newer.Name = "June 2026"
+	require.NoError(t, repo.CreateSession(ctx, newer))
+	require.NoError(t, repo.SetStatus(ctx, newer.ID, models.StatusCompleted))
+
+	// An active session must be excluded from history.
+	active := newGatheringSession(300)
+	require.NoError(t, repo.CreateSession(ctx, active))
+
+	past, err := repo.ListPastSessions(ctx, 0)
+	require.NoError(t, err)
+	require.Len(t, past, 2)
+	assert.Equal(t, "June 2026", past[0].Name, "newest first")
+	assert.Equal(t, "May 2026", past[1].Name)
+
+	limited, err := repo.ListPastSessions(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+	assert.Equal(t, "June 2026", limited[0].Name)
+}
+
+// --- helpers ---
+
+func newSessionRepo(t *testing.T, db *mongo.Database) *SessionRepository {
+	t.Helper()
+	repo, err := NewSessionRepository(db)
+	require.NoError(t, err)
+	require.NoError(t, repo.EnsureIndexes(testCtx(t)))
+	return repo
+}
+
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func newGatheringSession(subscriberID int64) *models.BookClubSession {
+	now := time.Now().UTC()
+	return &models.BookClubSession{
+		Name:      "June 2026",
+		Status:    models.StatusGathering,
+		CreatedBy: subscriberID,
+		Gathering: models.Gathering{
+			Deadline: now.Add(48 * time.Hour),
+			NotifyAt: now.Add(46 * time.Hour),
+			Participants: []*models.Participant{
+				{
+					SubscriberID: subscriberID,
+					FirstName:    "Test",
+					Step:         models.StepBook,
+					InvitedAt:    now,
+				},
+			},
+		},
+	}
+}
+
+func newVoting() *models.Voting {
+	now := time.Now().UTC()
+	return &models.Voting{
+		TelegramPollID:    42,
+		Deadline:          now.Add(24 * time.Hour),
+		NotifyAt:          now.Add(22 * time.Hour),
+		TotalParticipants: 2,
+		StartedAt:         now,
+	}
+}
+
+func cleanSession(clear func(), mongoDB *mongo.Database) {
+	clear()
+	mongo_helpers.DropCollection(mongoDB, sessions_collection)
+}


### PR DESCRIPTION
Closes #22

## Summary

Foundation (PR 1 of 2) for moving book-club round state out of memory into MongoDB so an in-flight round survives restarts, and to keep history. **No bot behavior change yet** — this is the data layer only. Bot wiring + the ticker recovery loop come in PR 2.

Design reference: `docs/book-club-flow.md`.

- **Models** (`internal/models/mongodb.go`) — rewritten session structs matching the doc: `BookClubSession`, `Gathering`, `Participant`, `Book`, `Voting`, `Winner`, reserved `Reading`/`ReadingMember`; status/step/reading constants; `IsActive()` helper. The `Participant` carries in-progress conversation `step`+partial `book` so a restart can resume each user mid-flow.
- **`SessionRepository`** (`internal/repository/session.go`) — `CreateSession`, `GetActiveSession`, `GetSessionById`, `UpdateParticipant`, `AddVoter` (idempotent `$addToSet`), `StartVoting`, `SetWinners`, `SetStatus`, `SetGatheringNotified`/`SetVotingNotified`, `ListPastSessions`, `EnsureIndexes`.
- **One active session at a time** — enforced by a unique partial index on an internal `activeLock` field (`$exists`). We can't use `partialFilterExpression: {status: {$in: [...]}}` because `$in` in partial indexes is only supported from **MongoDB 6.3**, while CI/prod run **6.0**. `$exists` works everywhere. `activeLock` is managed entirely by the repository and never read by app logic; `status` stays the source of truth. Rationale documented in the doc.
- **`voterIds` (array), not a counter** — needed for correct dedup/early-close across restarts, since Telegram doesn't reliably re-deliver historical `PollAnswer` updates.
- **Tests** (`internal/repository/session_test.go`) — integration tests mirroring the existing repository pattern; skipped under `-short` / when MongoDB is unavailable.
- **Docs** — `db-schema.md` marks the old draft superseded and points to `book-club-flow.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -short ./...` passes (integration tests skip without MongoDB)
- [ ] CI runs the session integration tests against `mongo:6.0` (single-active-session unique index, participant update, voter dedup, start-voting, winners, notified markers, history ordering/filtering)
- [ ] Confirm the unique partial `activeLock` index behaves on 6.0 in CI

---
🤖 Created by [Claude Code](https://claude.ai/code) · Model: claude-opus-4-8