### PR TITLE
Session recovery loop: drive deadlines from persisted state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,25 +43,45 @@ The Telegram **group ID** is persisted in the MongoDB `settings` collection and 
 cmd/main.go           → wires config, messages, MongoDB, repositories, then calls bot.Run()
 config/               → JSON-based config per environment
 message/              → JSON-based localized UI strings (locale-swappable)
-bot/                  → all Telegram bot logic (in-memory state machine)
+bot/                  → all Telegram bot logic (MongoDB-backed session lifecycle)
 internal/
   models/             → MongoDB BSON structs (Subscriber, BookClubSession, etc.)
-  repository/         → MongoDB repository layer (SubscriberRepository, SettingsRepository)
+  repository/         → MongoDB repository layer (SubscriberRepository, SettingsRepository, SessionRepository)
   repository/testing/ → test helpers for spinning up a real test MongoDB
 ```
 
 ### Bot state machine
 
-`bot.Bot` holds two in-memory structs:
+A book-club round is one **session** persisted in the `book_club_sessions`
+collection (`gathering → voting → reading → completed`/`cancelled`). The bot is
+**DB-authoritative**: handlers load the active session and write each transition
+through `SessionRepository` rather than holding round state in memory, so an
+in-flight round survives a restart. At most one session is active at a time,
+enforced by a unique partial index (see `docs/book-club-flow.md`).
 
-- **`bookGathering`** — tracks active participants and their multi-step book submission flow (`bookAsked → authorAsked → descriptionAsked → imageAsked → finished`). This state is **not persisted** to MongoDB (in-progress migration on `mongo_db_instead_of_memory` branch).
-- **`telegramPoll`** — tracks the active Telegram native poll (poll ID, participant count, who has voted).
+- **Book gathering** — `/start_vote` creates a session and DMs subscribers; each
+  participant's multi-step submission (`book → author → description → image →
+  done`, or `skipped`) is persisted on every step.
+- **Voting** — a Telegram native poll; votes are recorded with `$addToSet`, and
+  the poll closes on its deadline or once all eligible subscribers have voted.
+- **Recovery loop** (`bot/recovery.go`) — a single ~15s ticker is the only
+  driver of deadlines: it loads the active session, sends due reminders, and
+  advances gathering→voting and poll close from the session's persisted
+  timestamps. This makes restart-resume identical to normal operation; there are
+  no per-deadline `time.Sleep` goroutines.
 
-The main loop in `bot.Run()` dispatches Telegram updates: commands (`/subscribe`, `/start_vote`, `/skip`, `/help`) to handlers, free-text messages to `handleParticipantAnswer`, and `PollAnswer` updates to vote counting.
+The main loop in `bot.Run()` dispatches Telegram updates: commands (`/subscribe`,
+`/start_vote`, `/skip`, `/help`) to handlers, free-text messages to
+`handleUserMsg`, and `PollAnswer` updates to vote counting. Phase transitions are
+serialized under `bot.mu`.
 
 ### Repository layer
 
-Both repositories (`SubscriberRepository`, `SettingsRepository`) take `*mongo.Database` directly. `GetSubscriberById` returns `(nil, nil)` when the subscriber is not found (uses `mongo.ErrNoDocuments` internally).
+The repositories (`SubscriberRepository`, `SettingsRepository`,
+`SessionRepository`) take `*mongo.Database` directly. Lookups return `(nil, nil)`
+when not found (e.g. `GetSubscriberById`, `GetActiveSession`). `SessionRepository`
+enforces a single active session via a unique partial index on an internal
+`activeLock` field; `EnsureIndexes` is called at startup from `cmd/main.go`.
 
 ### Testing
 

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -399,7 +399,7 @@ func (b *Bot) handlePollAnswer(answer *tgbotapi.PollAnswer) {
 	if err != nil || updated == nil || updated.Voting == nil {
 		return
 	}
-	if len(updated.Voting.VoterIDs) >= updated.Voting.TotalParticipants {
+	if updated.Voting.TotalParticipants > 0 && len(updated.Voting.VoterIDs) >= updated.Voting.TotalParticipants {
 		b.closeTelegramPoll()
 	}
 }
@@ -548,25 +548,27 @@ func (b *Bot) runTelegramPoll(session *models.BookClubSession) error {
 }
 
 // closeTelegramPoll stops the poll, records the winner(s) and completes the
-// session. The critical section runs under b.mu so a deadline goroutine and an
+// session. The state-changing section runs under b.mu so a deadline tick and an
 // all-voted close cannot both drive it. The session is completed only AFTER
 // StopPoll succeeds: a failed StopPoll leaves it in voting so the close can be
-// retried (by a later vote, or PR 2b's recovery loop) instead of stranding an
-// open poll with no winner and a held active lock.
+// retried (by a later vote, or the recovery loop) instead of stranding an open
+// poll with no winner and a held active lock. announceWinner runs after the
+// lock is released — it is a plain group message and need not hold the lock.
 func (b *Bot) closeTelegramPoll() {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	if b.cfg.GroupId == 0 {
+		b.mu.Unlock()
 		log.Println("cannot close a telegram poll as GroupId is not innit")
 		return
 	}
 	session, err := b.sessionRepository.GetActiveSession(context.Background())
 	if err != nil {
+		b.mu.Unlock()
 		log.Printf("cannot get active session: %v", err)
 		return
 	}
 	if session == nil || session.Status != models.StatusVoting || session.Voting == nil {
+		b.mu.Unlock()
 		log.Print("there is not an active poll, cannot close it")
 		return
 	}
@@ -579,6 +581,7 @@ func (b *Bot) closeTelegramPoll() {
 	}
 	res, err := b.tgBot.StopPoll(finishPoll)
 	if err != nil {
+		b.mu.Unlock()
 		log.Printf("ERROR: %s", err)
 		return
 	}
@@ -592,9 +595,12 @@ func (b *Bot) closeTelegramPoll() {
 		log.Printf("cannot stamp poll close time: %v", err)
 	}
 	if err := b.sessionRepository.SetStatus(context.Background(), session.ID, models.StatusCompleted); err != nil {
+		b.mu.Unlock()
 		log.Printf("cannot complete session: %v", err)
 		return
 	}
+	b.mu.Unlock()
+
 	b.announceWinner(&res)
 }
 

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -63,6 +63,9 @@ func (b *Bot) Run() {
 
 	b.cfg.GroupId = int64(groupId)
 
+	// Drive deadlines and resume any in-flight round from persisted state.
+	b.startRecoveryLoop()
+
 	u := tgbotapi.NewUpdate(0)
 	u.Timeout = b.cfg.LongPollingTimeout
 
@@ -249,8 +252,8 @@ func (b *Bot) handleStartVote(update *tgbotapi.Update) error {
 		b.sendMessage(p.SubscriberID, b.messages.PleaseSuggestBookTitle)
 	}
 
-	b.deadlineNotificationBookGathering(time.Duration(b.cfg.TimeToGatherBooks-b.cfg.NotifyBeforeGathering) * time.Second)
-	b.runTelegramPollFlowAfterDelay(time.Duration(b.cfg.TimeToGatherBooks) * time.Second)
+	// The recovery loop drives the gathering reminder and the move to voting
+	// from the session's persisted deadlines.
 	return nil
 }
 
@@ -464,14 +467,6 @@ func (b *Bot) msgAboutGatheringBooks(session *models.BookClubSession) {
 	}
 }
 
-// runTelegramPollFlowAfterDelay runs runTelegramPollFlow after a delay.
-func (b *Bot) runTelegramPollFlowAfterDelay(delay time.Duration) {
-	go func() {
-		time.Sleep(delay)
-		b.runTelegramPollFlow()
-	}()
-}
-
 // runTelegramPollFlow ends the active book gathering and starts a telegram poll.
 // It claims the transition under b.mu by flipping the session to the voting
 // status; only the first caller that sees a gathering session proceeds.
@@ -506,8 +501,8 @@ func (b *Bot) runTelegramPollFlow() {
 		return
 	}
 
-	b.deadlineNotificationTelegramPoll(time.Duration(b.cfg.TimeForTelegramPoll-b.cfg.NotifyBeforePoll) * time.Second)
-	b.closeTelegramPollAfterDelay(time.Duration(b.cfg.TimeForTelegramPoll) * time.Second)
+	// The recovery loop drives the poll reminder and the close from the voting
+	// sub-document's persisted deadline.
 }
 
 // runTelegramPoll creates and starts a poll for choosing a book in the group,
@@ -552,14 +547,6 @@ func (b *Bot) runTelegramPoll(session *models.BookClubSession) error {
 	return b.sessionRepository.StartVoting(context.Background(), session.ID, voting)
 }
 
-// closeTelegramPollAfterDelay closes the poll after a given delay.
-func (b *Bot) closeTelegramPollAfterDelay(delay time.Duration) {
-	go func() {
-		time.Sleep(delay)
-		b.closeTelegramPoll()
-	}()
-}
-
 // closeTelegramPoll stops the poll, records the winner(s) and completes the
 // session. The critical section runs under b.mu so a deadline goroutine and an
 // all-voted close cannot both drive it. The session is completed only AFTER
@@ -600,6 +587,9 @@ func (b *Bot) closeTelegramPoll() {
 		if err := b.sessionRepository.SetWinners(context.Background(), session.ID, winners); err != nil {
 			log.Printf("cannot save winners: %v", err)
 		}
+	}
+	if err := b.sessionRepository.SetVotingClosed(context.Background(), session.ID, time.Now().UTC()); err != nil {
+		log.Printf("cannot stamp poll close time: %v", err)
 	}
 	if err := b.sessionRepository.SetStatus(context.Background(), session.ID, models.StatusCompleted); err != nil {
 		log.Printf("cannot complete session: %v", err)
@@ -671,48 +661,25 @@ func (b *Bot) pollOptionFor(bk *models.Book) string {
 	return fmt.Sprintf("%s: %s. %s: %s\n", b.messages.BookLabel, bk.Title, b.messages.AuthorLabel, bk.Author)
 }
 
-// deadlineNotificationBookGathering notifies participants who have not finished
-// before the gathering deadline. Delay is taken from a config.
-func (b *Bot) deadlineNotificationBookGathering(delay time.Duration) {
-	go func() {
-		time.Sleep(delay)
-
-		session, err := b.sessionRepository.GetActiveSession(context.Background())
-		if err != nil || session == nil || session.Status != models.StatusGathering {
-			return
+// notifyGatheringDeadline messages participants who have not finished before
+// the gathering deadline.
+func (b *Bot) notifyGatheringDeadline(session *models.BookClubSession) {
+	txt := fmt.Sprintf(b.messages.BookSubmissionDeadline, (time.Duration(b.cfg.NotifyBeforeGathering) * time.Second).Hours())
+	for _, p := range session.Gathering.Participants {
+		if p.Step != models.StepDone && p.Step != models.StepSkipped {
+			b.sendMessage(p.SubscriberID, txt)
 		}
-		var toNotify []int64
-		for _, p := range session.Gathering.Participants {
-			if p.Step != models.StepDone && p.Step != models.StepSkipped {
-				toNotify = append(toNotify, p.SubscriberID)
-			}
-		}
-
-		txt := fmt.Sprintf(b.messages.BookSubmissionDeadline, (time.Duration(b.cfg.NotifyBeforeGathering) * time.Second).Hours())
-		for _, id := range toNotify {
-			b.sendMessage(id, txt)
-		}
-	}()
+	}
 }
 
-// deadlineNotificationTelegramPoll notifies the group before the poll deadline.
-// Delay is taken from a config.
-func (b *Bot) deadlineNotificationTelegramPoll(delay time.Duration) {
-	go func() {
-		time.Sleep(delay)
-
-		if b.cfg.GroupId == 0 {
-			log.Println("cannot announce the deadline as GroupId is not innit")
-			return
-		}
-		session, err := b.sessionRepository.GetActiveSession(context.Background())
-		if err != nil || session == nil || session.Status != models.StatusVoting {
-			return
-		}
-
-		txt := fmt.Sprintf(b.messages.VotingEndsInHours, (time.Duration(b.cfg.NotifyBeforePoll) * time.Second).Hours())
-		b.sendMessage(b.cfg.GroupId, txt)
-	}()
+// notifyPollDeadline messages the group before the poll deadline.
+func (b *Bot) notifyPollDeadline() {
+	if b.cfg.GroupId == 0 {
+		log.Println("cannot announce the deadline as GroupId is not innit")
+		return
+	}
+	txt := fmt.Sprintf(b.messages.VotingEndsInHours, (time.Duration(b.cfg.NotifyBeforePoll) * time.Second).Hours())
+	b.sendMessage(b.cfg.GroupId, txt)
 }
 
 // findParticipant returns the participant with the given id, or nil.

--- a/bot/recovery.go
+++ b/bot/recovery.go
@@ -1,0 +1,92 @@
+package bot
+
+import (
+	"BookClubBot/internal/models"
+	"context"
+	"log"
+	"time"
+)
+
+// recoveryTickInterval is how often the recovery loop re-evaluates the active
+// session. A deadline may therefore fire up to one interval late, which is
+// irrelevant for a book club measured in days. See docs/book-club-flow.md.
+const recoveryTickInterval = 15 * time.Second
+
+// startRecoveryLoop launches the single goroutine that drives the active
+// session's lifecycle from its persisted timestamps. It is the only mechanism
+// that advances deadlines, so resuming after a restart is identical to normal
+// operation — the first tick simply acts on whatever the stored deadlines say.
+//
+// Ticks run sequentially in one goroutine (a slow tick delays the next rather
+// than overlapping it), so no extra locking is needed beyond the b.mu already
+// taken by the transition helpers it calls.
+func (b *Bot) startRecoveryLoop() {
+	go func() {
+		b.recoverTick() // immediate resume on startup, before the first interval
+		ticker := time.NewTicker(recoveryTickInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			b.recoverTick()
+		}
+	}()
+}
+
+// recoverTick evaluates the active session once and acts on anything due.
+func (b *Bot) recoverTick() {
+	session, err := b.sessionRepository.GetActiveSession(context.Background())
+	if err != nil {
+		log.Printf("recovery: cannot get active session: %v", err)
+		return
+	}
+	if session == nil {
+		return
+	}
+
+	now := time.Now().UTC()
+	switch session.Status {
+	case models.StatusGathering:
+		b.recoverGathering(session, now)
+	case models.StatusVoting:
+		b.recoverVoting(session, now)
+	}
+}
+
+// recoverGathering sends the due reminder and moves to voting once the deadline
+// passes (or everyone has finished/skipped).
+func (b *Bot) recoverGathering(session *models.BookClubSession, now time.Time) {
+	if session.Gathering.NotifiedAt == nil && !now.Before(session.Gathering.NotifyAt) {
+		b.notifyGatheringDeadline(session)
+		if err := b.sessionRepository.SetGatheringNotified(context.Background(), session.ID, now); err != nil {
+			log.Printf("recovery: cannot mark gathering notified: %v", err)
+		}
+	}
+
+	if allBooksChosen(session) || !now.Before(session.Gathering.Deadline) {
+		b.runTelegramPollFlow()
+	}
+}
+
+// recoverVoting sends the due reminder and closes the poll once the deadline
+// passes (or everyone has voted). A voting session with no voting sub-document
+// is a wedged round (the poll never started) and is cancelled to release the
+// active lock.
+func (b *Bot) recoverVoting(session *models.BookClubSession, now time.Time) {
+	if session.Voting == nil {
+		log.Printf("recovery: voting session %s has no voting sub-document, cancelling", session.ID.Hex())
+		if err := b.sessionRepository.SetStatus(context.Background(), session.ID, models.StatusCancelled); err != nil {
+			log.Printf("recovery: cannot cancel wedged session: %v", err)
+		}
+		return
+	}
+
+	if session.Voting.NotifiedAt == nil && !now.Before(session.Voting.NotifyAt) {
+		b.notifyPollDeadline()
+		if err := b.sessionRepository.SetVotingNotified(context.Background(), session.ID, now); err != nil {
+			log.Printf("recovery: cannot mark voting notified: %v", err)
+		}
+	}
+
+	if len(session.Voting.VoterIDs) >= session.Voting.TotalParticipants || !now.Before(session.Voting.Deadline) {
+		b.closeTelegramPoll()
+	}
+}

--- a/bot/recovery.go
+++ b/bot/recovery.go
@@ -12,6 +12,14 @@ import (
 // irrelevant for a book club measured in days. See docs/book-club-flow.md.
 const recoveryTickInterval = 15 * time.Second
 
+// wedgedVotingGrace is how long a session may legitimately sit in the voting
+// status with no voting sub-document — the window inside runTelegramPollFlow
+// between claiming the transition and StartVoting writing the sub-document
+// (media upload + poll send). Only past this grace is such a session treated as
+// wedged and cancelled, so the recovery loop never reaps a round that is
+// actively launching its poll.
+const wedgedVotingGrace = 2 * time.Minute
+
 // startRecoveryLoop launches the single goroutine that drives the active
 // session's lifecycle from its persisted timestamps. It is the only mechanism
 // that advances deadlines, so resuming after a restart is identical to normal
@@ -72,9 +80,16 @@ func (b *Bot) recoverGathering(session *models.BookClubSession, now time.Time) {
 // active lock.
 func (b *Bot) recoverVoting(session *models.BookClubSession, now time.Time) {
 	if session.Voting == nil {
-		log.Printf("recovery: voting session %s has no voting sub-document, cancelling", session.ID.Hex())
-		if err := b.sessionRepository.SetStatus(context.Background(), session.ID, models.StatusCancelled); err != nil {
-			log.Printf("recovery: cannot cancel wedged session: %v", err)
+		// status=voting with no voting sub-document is legitimate while
+		// runTelegramPollFlow is mid-launch; only cancel once it has stayed that
+		// way past the grace period (i.e. the launch crashed), so we never reap a
+		// round that is actively starting its poll. UpdatedAt is stamped when the
+		// status was flipped to voting.
+		if now.Sub(session.UpdatedAt) > wedgedVotingGrace {
+			log.Printf("recovery: voting session %s has no voting sub-document past grace, cancelling", session.ID.Hex())
+			if err := b.sessionRepository.SetStatus(context.Background(), session.ID, models.StatusCancelled); err != nil {
+				log.Printf("recovery: cannot cancel wedged session: %v", err)
+			}
 		}
 		return
 	}
@@ -86,7 +101,8 @@ func (b *Bot) recoverVoting(session *models.BookClubSession, now time.Time) {
 		}
 	}
 
-	if len(session.Voting.VoterIDs) >= session.Voting.TotalParticipants || !now.Before(session.Voting.Deadline) {
+	allVoted := session.Voting.TotalParticipants > 0 && len(session.Voting.VoterIDs) >= session.Voting.TotalParticipants
+	if allVoted || !now.Before(session.Voting.Deadline) {
 		b.closeTelegramPoll()
 	}
 }

--- a/bot/recovery_test.go
+++ b/bot/recovery_test.go
@@ -1,0 +1,73 @@
+package bot
+
+import (
+	"BookClubBot/internal/models"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// fakeSessionRepo records the calls the recovery loop makes. Methods not needed
+// by a given test are no-ops.
+type fakeSessionRepo struct {
+	statusSet     []string
+	gatherNotify  int
+	votingNotify  int
+	votingClosed  int
+	startedVoting int
+}
+
+func (f *fakeSessionRepo) CreateSession(context.Context, *models.BookClubSession) error {
+	return nil
+}
+func (f *fakeSessionRepo) GetActiveSession(context.Context) (*models.BookClubSession, error) {
+	return nil, nil
+}
+func (f *fakeSessionRepo) UpdateParticipant(context.Context, primitive.ObjectID, *models.Participant) error {
+	return nil
+}
+func (f *fakeSessionRepo) AddVoter(context.Context, primitive.ObjectID, int64) error { return nil }
+func (f *fakeSessionRepo) StartVoting(context.Context, primitive.ObjectID, *models.Voting) error {
+	f.startedVoting++
+	return nil
+}
+func (f *fakeSessionRepo) SetWinners(context.Context, primitive.ObjectID, []models.Winner) error {
+	return nil
+}
+func (f *fakeSessionRepo) SetStatus(_ context.Context, _ primitive.ObjectID, status string) error {
+	f.statusSet = append(f.statusSet, status)
+	return nil
+}
+func (f *fakeSessionRepo) SetGatheringNotified(context.Context, primitive.ObjectID, time.Time) error {
+	f.gatherNotify++
+	return nil
+}
+func (f *fakeSessionRepo) SetVotingNotified(context.Context, primitive.ObjectID, time.Time) error {
+	f.votingNotify++
+	return nil
+}
+func (f *fakeSessionRepo) SetVotingClosed(context.Context, primitive.ObjectID, time.Time) error {
+	f.votingClosed++
+	return nil
+}
+
+func TestRecoverVotingCancelsWedgedSession(t *testing.T) {
+	fake := &fakeSessionRepo{}
+	b := &Bot{sessionRepository: fake}
+
+	// status=voting but no voting sub-document: the poll never started.
+	session := &models.BookClubSession{
+		ID:     primitive.NewObjectID(),
+		Status: models.StatusVoting,
+		Voting: nil,
+	}
+
+	b.recoverVoting(session, time.Now().UTC())
+
+	assert.Equal(t, []string{models.StatusCancelled}, fake.statusSet,
+		"a voting session with no voting sub-document should be cancelled")
+	assert.Equal(t, 0, fake.votingClosed, "wedged session must not be closed")
+}

--- a/bot/recovery_test.go
+++ b/bot/recovery_test.go
@@ -54,20 +54,38 @@ func (f *fakeSessionRepo) SetVotingClosed(context.Context, primitive.ObjectID, t
 	return nil
 }
 
-func TestRecoverVotingCancelsWedgedSession(t *testing.T) {
-	fake := &fakeSessionRepo{}
-	b := &Bot{sessionRepository: fake}
+func TestRecoverVotingWedgedSession(t *testing.T) {
+	now := time.Now().UTC()
 
-	// status=voting but no voting sub-document: the poll never started.
-	session := &models.BookClubSession{
-		ID:     primitive.NewObjectID(),
-		Status: models.StatusVoting,
-		Voting: nil,
-	}
+	t.Run("recent voting==nil is mid-launch, not cancelled", func(t *testing.T) {
+		fake := &fakeSessionRepo{}
+		b := &Bot{sessionRepository: fake}
+		session := &models.BookClubSession{
+			ID:        primitive.NewObjectID(),
+			Status:    models.StatusVoting,
+			Voting:    nil,
+			UpdatedAt: now.Add(-5 * time.Second), // within grace
+		}
 
-	b.recoverVoting(session, time.Now().UTC())
+		b.recoverVoting(session, now)
 
-	assert.Equal(t, []string{models.StatusCancelled}, fake.statusSet,
-		"a voting session with no voting sub-document should be cancelled")
-	assert.Equal(t, 0, fake.votingClosed, "wedged session must not be closed")
+		assert.Empty(t, fake.statusSet, "a round still launching its poll must not be cancelled")
+	})
+
+	t.Run("stale voting==nil past grace is cancelled", func(t *testing.T) {
+		fake := &fakeSessionRepo{}
+		b := &Bot{sessionRepository: fake}
+		session := &models.BookClubSession{
+			ID:        primitive.NewObjectID(),
+			Status:    models.StatusVoting,
+			Voting:    nil,
+			UpdatedAt: now.Add(-wedgedVotingGrace - time.Second), // past grace
+		}
+
+		b.recoverVoting(session, now)
+
+		assert.Equal(t, []string{models.StatusCancelled}, fake.statusSet,
+			"a wedged voting session should be cancelled to release the lock")
+		assert.Equal(t, 0, fake.votingClosed, "wedged session must not be closed")
+	})
 }

--- a/bot/repository.go
+++ b/bot/repository.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"BookClubBot/internal/models"
 	"context"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -27,4 +28,7 @@ type sessionRepo interface {
 	StartVoting(ctx context.Context, id primitive.ObjectID, voting *models.Voting) error
 	SetWinners(ctx context.Context, id primitive.ObjectID, winners []models.Winner) error
 	SetStatus(ctx context.Context, id primitive.ObjectID, status string) error
+	SetGatheringNotified(ctx context.Context, id primitive.ObjectID, at time.Time) error
+	SetVotingNotified(ctx context.Context, id primitive.ObjectID, at time.Time) error
+	SetVotingClosed(ctx context.Context, id primitive.ObjectID, at time.Time) error
 }

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -56,14 +56,15 @@ Single-document collection. Stores bot-level runtime settings that must survive 
 
 ---
 
-## Models defined but not yet persisted
+## Session models — earlier draft (historical)
 
-> **Superseded.** The session schema below is an earlier draft. The authoritative
-> design for the book-club round (gathering → voting → reading) and its MongoDB
-> schema now lives in [`book-club-flow.md`](./book-club-flow.md). Follow that doc
-> for the feature; the section below is kept only for historical reference.
+> **Superseded.** The `book_club_sessions` collection is now live, but the schema
+> sketched below is an **earlier draft** and no longer matches the code. The
+> authoritative design for the book-club round (gathering → voting → reading) and
+> its MongoDB schema lives in [`book-club-flow.md`](./book-club-flow.md). The
+> section below is kept only for historical reference.
 
-The following structs exist in `internal/models/mongodb.go` and have BSON tags, but there is currently **no repository or collection** wired up for them. They represent the intended next phase of the schema (replacing in-memory state with MongoDB).
+The following describes the original draft structs in `internal/models/mongodb.go`. They have since been reworked and persisted via `SessionRepository`; see `book-club-flow.md` for the current shape.
 
 ### `BookClubSession` (planned collection: `book_club_sessions`)
 
@@ -155,4 +156,4 @@ Top-level document for one complete voting round — from opening book suggestio
 |---|---|---|
 | `subscribers` | **Live** | Full CRUD via `SubscriberRepository` |
 | `settings` | **Live** | Single-document store for `groupId` |
-| `book_club_sessions` | **Planned** | Models defined; no repository yet. Session state is currently held in-memory in `bot.bookGathering` and `bot.telegramPoll` and lost on restart. |
+| `book_club_sessions` | **Live** | Full lifecycle via `SessionRepository`; the bot is DB-authoritative and resumes in-flight rounds after a restart. Schema and behavior: [`book-club-flow.md`](./book-club-flow.md). |

--- a/internal/repository/session.go
+++ b/internal/repository/session.go
@@ -232,6 +232,11 @@ func (s *SessionRepository) SetVotingNotified(ctx context.Context, id primitive.
 	return s.setField(ctx, id, "voting.notifiedAt", at.UTC())
 }
 
+// SetVotingClosed stamps the time the poll was closed.
+func (s *SessionRepository) SetVotingClosed(ctx context.Context, id primitive.ObjectID, at time.Time) error {
+	return s.setField(ctx, id, "voting.closedAt", at.UTC())
+}
+
 // ListPastSessions returns completed sessions, newest first, up to limit
 // (limit <= 0 means no limit).
 func (s *SessionRepository) ListPastSessions(ctx context.Context, limit int64) ([]*models.BookClubSession, error) {

--- a/internal/repository/session_test.go
+++ b/internal/repository/session_test.go
@@ -223,13 +223,16 @@ func TestSetGatheringAndVotingNotified(t *testing.T) {
 	at := time.Now().UTC().Truncate(time.Millisecond)
 	require.NoError(t, repo.SetGatheringNotified(ctx, session.ID, at))
 	require.NoError(t, repo.SetVotingNotified(ctx, session.ID, at))
+	require.NoError(t, repo.SetVotingClosed(ctx, session.ID, at))
 
 	stored, err := repo.GetSessionById(ctx, session.ID)
 	require.NoError(t, err)
 	require.NotNil(t, stored.Gathering.NotifiedAt)
 	require.NotNil(t, stored.Voting.NotifiedAt)
+	require.NotNil(t, stored.Voting.ClosedAt)
 	assert.Equal(t, at, stored.Gathering.NotifiedAt.UTC())
 	assert.Equal(t, at, stored.Voting.NotifiedAt.UTC())
+	assert.Equal(t, at, stored.Voting.ClosedAt.UTC())
 }
 
 func TestListPastSessions(t *testing.T) {


### PR DESCRIPTION
Closes #26

## Summary

PR 2b, the final piece of the persistence work. Replaces the per-deadline `time.Sleep` goroutines with the single ticker recovery loop from `docs/book-club-flow.md`. An in-flight round now **resumes after a restart** instead of stalling, and the lifecycle is driven entirely from the session's persisted timestamps.

Builds on #25 (bot wiring) and #23 (data layer).

### What changed
- **`startRecoveryLoop`** — one goroutine that runs an immediate tick (startup resume) and then re-evaluates the active session every 15s. Ticks run sequentially in the one goroutine, so there are no overlapping passes and no extra locking beyond the `b.mu` the transition helpers already take.
- **`recoverGathering`** — sends the gathering reminder when due (idempotent via `gathering.notifiedAt`) and transitions to voting at `gathering.deadline` or once everyone has finished/skipped.
- **`recoverVoting`** — sends the poll reminder (`voting.notifiedAt`), closes the poll at `voting.deadline` or once all eligible voters have voted, and **cancels a wedged session** (`status=voting` with `voting == nil`, i.e. the poll never started) to release the active lock.
- **Removed** `runTelegramPollFlowAfterDelay`, `closeTelegramPollAfterDelay`, and the `deadlineNotification*` goroutines; `handleStartVote`/`runTelegramPollFlow` no longer schedule timers. This also eliminates the **orphaned-timer bug** (a leftover timer from a finished round driving a later one), since the ticker keys off the active session's own deadline.
- **`voting.closedAt`** is now stamped on close via a new `SetVotingClosed` repository method.

### Review items from #25 resolved here
- ✅ Ticker recovery loop + startup resume
- ✅ Orphan-timer removal
- ✅ Wedged `voting == nil` detection/cancel
- ✅ `voting.closedAt` stamping

Still intentionally **out of scope** (noted in #26): restricting poll votes to subscribers (pre-existing semantics); step 3 reading/reviews.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -short ./...` passes; new tests: wedged-session cancel (fake repo), `SetVotingClosed` persistence
- [ ] CI runs repository integration tests against `mongo:6.0`
- [ ] Manual (optional): start a round, restart the process mid-gathering, confirm the ticker advances it to voting at the deadline and closes the poll; confirm `voting.closedAt` is set in Mongo

---
🤖 Created by [Claude Code](https://claude.ai/code) · Model: claude-opus-4-8