### PR TITLE
Improve feature-work skills (independent review, start-issue, address-review)

### DIFF
--- a/.claude/skills/address-review/SKILL.md
+++ b/.claude/skills/address-review/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: address-review
+description: After a review, triage the open inline PR comments, apply fixes, push, and reply to every comment with the fix commit SHA (or a reject reason); offer to roll deferred findings into a follow-up issue.
+argument-hint: 'optional PR number (default: the PR for the current branch)'
+allowed-tools: [Bash, Agent]
+---
+
+# address-review
+
+Closes the loop on a reviewed PR. Every inline comment must end with a reply —
+either the fix or an explicit reason it was skipped (CLAUDE.md workflow step 5).
+
+## Steps
+
+### Step 1: Gather the open inline comments
+
+```bash
+PR=<n>   # or: gh pr view --json number -q .number
+gh api repos/<owner>/<repo>/pulls/$PR/comments --paginate \
+  -q '.[] | "id:\(.id) path:\(.path) line:\(.line // .original_line)\n\(.body)\n"'
+```
+
+Include comments from any reviewer (human, this project's review agent, external
+bots like Codex). Skip ones that already have your reply.
+
+### Step 2: Triage each finding
+
+For each, decide and note the disposition:
+- **Fix** — a real bug/cleanup in scope for this PR.
+- **Defer** — real but belongs in a follow-up (out of this PR's scope).
+- **Reject** — not a real problem (factually wrong, already handled, or pure
+  style). Be willing to reject with a concrete reason; reviewers (including
+  automated ones) lack full context and can be wrong.
+
+When unsure whether a flagged bug is real, you may spawn an `Agent` to verify it
+against the code before deciding.
+
+### Step 3: Apply the fixes
+
+Make the code changes for the "Fix" items. Then, from the repo root:
+
+```bash
+gofmt -w <changed-files>
+go build ./... && go vet ./... && go test -short ./...
+```
+
+Commit with a message that summarizes what the review changed, and push.
+
+### Step 4: Reply to every comment
+
+For each comment, post a reply with the fix commit SHA and a one-line summary, or
+the reason it was deferred/rejected:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/$PR/comments/<comment-id>/replies -X POST \
+  -f body="Fixed in <sha>: <what changed>."     # or "Deferred to #<m>: ..." / "Not a bug: <why>."
+```
+
+### Step 5: Deferred findings → follow-up issue
+
+If anything was deferred, offer to capture it: append to an existing follow-up
+issue or open a new one (`gh issue create`), and reference that issue number in
+the corresponding replies.
+
+### Step 6: Confirm CI and report
+
+Wait for CI on the new commit, then report: what was fixed / deferred / rejected,
+the follow-up issue (if any), CI status, and that the PR is ready for merge.

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -54,6 +54,13 @@ After pushing, tell the user:
 - The tag that was created (e.g. `v0.4.7`)
 - The Docker image that will be produced: `beskar18/book-club-bot:v0.4.7`
 - How to watch the CI run: `gh run list --limit 3` or the GitHub Actions URL
+- That building/pushing the image does NOT redeploy a running env — the target
+  must pull the new tag (or be redeployed) to pick it up.
+- For a **sandbox smoke test**, remind them of the prerequisites that otherwise
+  silently block testing: a `telegrammApiKey`, a reachable MongoDB, the bot
+  added to a group (sets `groupId`), and a **short-duration config** — prod uses
+  86400s (24h) for gather/poll, so a round there takes two days; point
+  `APP_ENV` at the dev config (60s) to exercise a full round in minutes.
 
 ### Step 5: Optional — watch CI
 

--- a/.claude/skills/finish-issue/SKILL.md
+++ b/.claude/skills/finish-issue/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: finish-issue
-description: End-of-issue workflow — verifies the PR is open and properly linked to an issue, then triggers an independent code review that posts findings as inline PR comments.
-argument-hint: 'optional: effort level — low | medium | high | ultra (default: high)'
-allowed-tools: [Bash]
+description: End-of-issue workflow — verifies the PR is open and linked to an issue, then runs a genuinely independent (cold-context) code review that posts findings as inline PR comments.
+argument-hint: 'optional: effort level — low | medium | high (default: high)'
+allowed-tools: [Bash, Agent]
 ---
 
 # finish-issue
 
 Runs the end-of-issue checklist after implementation is done and a PR is open.
+
+The whole point of this step is an **unbiased** review. The author of a change
+is the worst person to spot its blind spots, so the review MUST run in a fresh
+agent that has no context from the implementation session — never review the diff
+inline in the current session. (This was learned the hard way: an inline
+self-review missed a real concurrency race that a cold-context agent caught.)
 
 ## Steps
 
@@ -26,20 +32,37 @@ Abort with a clear message if:
 
 Inspect the PR body for `Closes #N`. If it's missing, warn the user — the PR should reference an issue before review. Do not abort; just flag it.
 
-### Step 3: Run independent code review
+### Step 3: Run an independent, cold-context review
 
-Invoke the built-in code-review skill at the requested effort level (default `high`) with `--comment` so findings land as inline PR comments rather than in this session's output:
+Spawn a **fresh `Agent`** (subagent_type `general-purpose`) to do the review. Do
+NOT review the diff yourself in this session. Give the agent a self-contained
+prompt — it knows nothing about the change — that tells it to:
 
+- Gather the scope with `git -C <repo> diff main...HEAD` (fall back to `git diff HEAD~1` if needed).
+- Read the changed files AND the surrounding code/contracts they depend on.
+- Hunt for bugs across angles: line-by-line correctness, removed-behavior, cross-file/contract, concurrency (races, double-fire, lock held across I/O, TOCTOU), plus reuse/simplification/efficiency cleanups.
+- Verify each candidate against the actual code (quote the line); drop refuted ones; keep CONFIRMED and realistic-PLAUSIBLE.
+- Return ONLY a JSON array (max 10), most-severe first: `{"file","line","summary","failure_scenario"}`. Do NOT let it post to GitHub — it just returns JSON.
+
+Scale breadth with the effort arg (default `high` = recall-biased, surface more).
+
+### Step 4: Post findings as inline PR comments
+
+For each finding the agent returns, post an inline comment on the PR:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<n>/comments -X POST \
+  -f commit_id="<head-sha>" -f path="<file>" -F line=<line> -f side="RIGHT" \
+  -f body="<summary + failure scenario>"
 ```
-/code-review <effort> --comment
-```
 
-This spawns a fresh agent with no context from the current implementation session, giving an unbiased read of the diff.
+Use the PR head SHA (`gh pr view --json headRefOid -q .headRefOid`). If a finding's
+line isn't in the diff, post it on the nearest changed line and say so in the body.
 
-### Step 4: Report
+### Step 5: Report
 
-After the review completes, tell the user:
-- The PR URL
-- The effort level used
-- That review comments (if any) are now on the PR
-- That the issue is ready for their review and merge
+Tell the user:
+- The PR URL and the effort level used
+- That the review ran in an independent cold-context agent
+- A short summary of the findings (count + headline issues), and that they're now inline on the PR
+- That the next step is to address them with `address-review`, then it's ready for their merge

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: start-issue
+description: Start a unit of work the project's way — create a GitHub issue, branch off fresh main as feat/|fix/<slug>, and provide the mandated PR template for when implementation is done.
+argument-hint: 'a short description of the work (e.g. "persist voting state")'
+allowed-tools: [Bash, AskUserQuestion]
+---
+
+# start-issue
+
+Opens the front of the issue → branch → PR flow defined in CLAUDE.md, so the
+ritual is consistent every time. (Never push directly to `main`; every change
+gets its own branch and PR.)
+
+## Steps
+
+### Step 1: Decide title and type
+
+From the argument, draft a concise issue title and pick the type:
+- `feat` — new behavior/feature
+- `fix` — bug fix
+
+If the type is ambiguous, ask with AskUserQuestion. Derive a kebab-case `<slug>`
+from the title (e.g. "Persist voting state" → `persist-voting-state`).
+
+### Step 2: Create the issue
+
+```bash
+gh issue create --title "<title>" --body "<body>"
+```
+
+Body should state the problem/goal and a short checklist of scope. Capture the
+issue number `N` from the URL it prints.
+
+### Step 3: Branch off fresh main
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b <feat|fix>/<slug>
+```
+
+Abort if `main` has uncommitted changes (warn the user first).
+
+### Step 4: Report + hand over the PR template
+
+Tell the user the issue number, the branch name, and that they can start
+implementing. Remind them: when the work is done, open the PR with this exact
+structure (first line MUST be `Closes #N` so GitHub auto-closes the issue):
+
+```
+Closes #N
+
+## Summary
+...
+
+## Test plan
+- [ ] ...
+
+---
+🤖 Created by [Claude Code](https://claude.ai/code) · Model: <active model id>
+```
+
+Fill `Model:` with the model actually in use (do not hardcode a stale id), e.g.:
+
+```bash
+gh pr create --base main --head <feat|fix>/<slug> --title "<title>" --body "$(cat <<'EOF'
+Closes #N
+...
+EOF
+)"
+```
+
+After the PR is open, the natural next steps are `finish-issue` (independent
+review) and then `address-review`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,5 +112,7 @@ Closes #N
 - [ ] ...
 
 ---
-🤖 Created by [Claude Code](https://claude.ai/code) · Model: claude-sonnet-4-6
+🤖 Created by [Claude Code](https://claude.ai/code) · Model: <active model id>
 ```
+
+Fill `Model:` with the model actually in use when opening the PR — do not hardcode a specific id here, as it goes stale.


### PR DESCRIPTION
Closes #30

## Summary

Tightens the project's custom skills based on friction observed delivering the session-persistence feature (#22/#24/#26/#28).

- **`finish-issue` (adjust)** — the review wasn't actually independent: it invoked `/code-review` inline, so the author re-reviewed their own diff (an inline self-review missed a real concurrency race that a cold-context agent later caught). It now spawns a fresh `general-purpose` `Agent` with a self-contained prompt and posts the returned findings as inline PR comments. `allowed-tools` gains `Agent`.
- **`start-issue` (new)** — codifies issue → branch off fresh `main` (`feat|fix/<slug>`) → PR with the mandated body structure, including filling the PR-footer model id instead of hardcoding a stale one.
- **`address-review` (new)** — triage inline comments (fix / defer / reject), apply fixes, push, reply to **every** comment with the fix SHA or a reason, and roll deferred findings into a follow-up issue (CLAUDE.md workflow step 5).
- **`deploy` (minor)** — report step now flags that building the image doesn't redeploy a running env, and lists the sandbox smoke-test prerequisites (token, MongoDB, group, short-duration config vs prod's 24h).
- **`CLAUDE.md` (minor)** — PR-footer template no longer hardcodes a stale model id.

## Test plan
- [x] Skills/docs only — no Go changed; `go test -short ./...` unaffected
- [x] Each new/edited `SKILL.md` has valid frontmatter (`name`, `description`, `allowed-tools`)
- [ ] CI green
- [ ] Next real PR uses `start-issue` → `finish-issue` (independent agent) → `address-review` end-to-end

---
🤖 Created by [Claude Code](https://claude.ai/code) · Model: claude-opus-4-8